### PR TITLE
Do not exit AlarmHandler when not in fuzzing thread

### DIFF
--- a/compiler-rt/lib/fuzzer/FuzzerLoop.cpp
+++ b/compiler-rt/lib/fuzzer/FuzzerLoop.cpp
@@ -282,8 +282,10 @@ void Fuzzer::AlarmCallback() {
   // In Windows and Fuchsia, Alarm callback is executed by a different thread.
   // NetBSD's current behavior needs this change too.
 #if !LIBFUZZER_WINDOWS && !LIBFUZZER_NETBSD && !LIBFUZZER_FUCHSIA
-  if (!InFuzzingThread())
-    return;
+  // When launched within the JVM, the alarm callback is executed by a different
+  // thread. The JVM doesn't seem to use SIGALRM for regular functionality.
+  // if (!InFuzzingThread())
+  //   return;
 #endif
   if (!RunningUserCallback)
     return; // We have not started running units yet.


### PR DESCRIPTION
When launched within the JVM, the registered handler for SIGALRM runs in a different thread and thus skipped the actual timeout detection logic.